### PR TITLE
fix updatePreview and add menu for darwin

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,11 +18,130 @@ app.on('ready', function() {
   // メイン画面の表示。ウィンドウの幅、高さを指定
   mainWindow = new BrowserWindow({width: 1024, height: 768});
   // デフォルトで開発ツールを開く
-  //mainWindow.openDevTools();
+  // mainWindow.openDevTools();
   mainWindow.loadURL('file://' + __dirname + '/index.html');
+
+  installMenu();
 
   // ウィンドウが閉じられたらアプリも終了
   mainWindow.on('closed', function() {
     mainWindow = null;
   });
 });
+
+function installMenu() {
+  var Menu = require('menu');
+  if(process.platform == 'darwin') {
+    var template = [{
+      label: 'electron-viz',
+      submenu: [
+        {
+          label: 'About electron-viz',
+          selector: 'orderFrontStandardAboutPanel:'
+        },
+        {
+          type: 'separator'
+        },
+        {
+          label: 'Hide Electron',
+          accelerator: 'Command+H',
+          selector: 'hide:'
+        },
+        {
+          label: 'Hide Others',
+          accelerator: 'Command+Shift+H',
+          selector: 'hideOtherApplications:'
+        },
+        {
+          label: 'Show All',
+          selector: 'unhideAllApplications:'
+        },
+        {
+          type: 'separator'
+        },
+        {
+          label: 'Quit',
+          accelerator: 'Command+Q',
+          click: function() { app.quit(); }
+        },
+      ]
+    },
+    {
+      label: 'Edit',
+      submenu: [
+        {
+          label: 'Undo',
+          accelerator: 'Command+Z',
+          selector: 'undo:'
+        },
+        {
+          label: 'Redo',
+          accelerator: 'Shift+Command+Z',
+          selector: 'redo:'
+        },
+        {
+          type: 'separator'
+        },
+        {
+          label: 'Cut',
+          accelerator: 'Command+X',
+          selector: 'cut:'
+        },
+        {
+          label: 'Copy',
+          accelerator: 'Command+C',
+          selector: 'copy:'
+        },
+        {
+          label: 'Paste',
+          accelerator: 'Command+V',
+          selector: 'paste:'
+        },
+        {
+          label: 'Select All',
+          accelerator: 'Command+A',
+          selector: 'selectAll:'
+        },
+      ]
+    },
+    {
+      label: 'View',
+      submenu: [
+        {
+          label: 'Reload',
+          accelerator: 'Command+R',
+          click: function() { BrowserWindow.getFocusedWindow().reloadIgnoringCache(); }
+        },
+        {
+          label: 'Toggle DevTools',
+          accelerator: 'Alt+Command+I',
+          click: function() { BrowserWindow.getFocusedWindow().toggleDevTools(); }
+        },
+      ]
+    },
+    {
+      label: 'Window',
+      submenu: [
+        {
+          label: 'Minimize',
+          accelerator: 'Command+M',
+          selector: 'performMiniaturize:'
+        },
+        {
+          label: 'Close',
+          accelerator: 'Command+W',
+          selector: 'performClose:'
+        },
+        {
+          type: 'separator'
+        },
+        {
+          label: 'Bring All to Front',
+          selector: 'arrangeInFront:'
+        },
+      ]
+    }];
+    var menu = Menu.buildFromTemplate(template);
+    Menu.setApplicationMenu(menu);
+  }
+}


### PR DESCRIPTION
Viz.jsに不完全なDOTを渡すとsyntax errorが出て、プレビュー画面が更新されなくなる場合があるので、エラーハンドリングを加えた。
また、syntax errorが出ている状況でmessageを表示するように変更。

darwin (OS X)環境下では、Copy / Cut / Pasteなどが行えないので、
編集メニューなどを追加。
